### PR TITLE
Fix meeting notes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,7 @@ title: MITI
 description: Minimum Information about Tissue Images
 
 remote_theme: pmarsceill/just-the-docs
+
+collections:
+  meeting-notes:
+    output: true

--- a/_meeting-notes/2022-01-12.md
+++ b/_meeting-notes/2022-01-12.md
@@ -1,7 +1,6 @@
 ---
-style: default
-name: 2022-01-12 Meeting notes
-
+layout: default
+title: 2022-01-12 MITI Governance Board Meeting
 ---
 # 2022-01-12 MITI Governance Board Meeting
 

--- a/governance.md
+++ b/governance.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Governance
-nav-order: 2
+nav_order: 2
 ---
 
 # Governance

--- a/governance.md
+++ b/governance.md
@@ -31,4 +31,12 @@ MITI Governance Board meetings occur quarterly and are open to the public. Dates
 *To be announced*
 
 ### Previous MITI Meeting Minutes
-- [2022-01-13 Meeting Notes]({% link _documents/20220113-notes.md %})
+
+<ul>
+    {% assign notes = site.meeting-notes | reverse %}
+    {% for note in notes %}
+    <li>
+        <a href="{{ note.url }}">{{ note.title }}</a>
+    </li>
+    {% endfor %}
+</ul>

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Home
-nav-order: 1
+nav_order: 1
 ---
 
 # MITI: Minimum Information about Tissue Imaging


### PR DESCRIPTION
- rename documents to meeting-notes
- Auto-index meeting notes to the governance page when a note is added to the `_meeting-notes/`